### PR TITLE
Add permanent redirect to uxit.fil.org

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/*"
+  to = "https://uxit.fil.org/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
This PR introduces a 301 permanent redirect rule for all traffic coming to `uxit.netlify.app` to be redirected to `https://uxit.fil.org/`. The change ensures that all users and search engines are directed to the new primary domain, which helps in maintaining SEO rankings and provides a unified user experience.