### PR TITLE
Revert "Add permanent redirect to uxit.fil.org"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,5 +1,0 @@
-[[redirects]]
-  from = "/*"
-  to = "https://uxit.fil.org/:splat"
-  status = 301
-  force = true


### PR DESCRIPTION
Reverts FilecoinFoundationWeb/uxit#2 because its causing a redirect loop.