### PR TITLE
Implement redirect from Netlify subdomain to custom domain

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "https://uxit.netlify.app/*"
+  to = "https://uxit.fil.org/:splat"
+  status = 301
+  force = true


### PR DESCRIPTION
This PR addresses the redirect loop issue between the Netlify subdomain uxit.netlify.app and the custom domain uxit.fil.org. Previously (#2), configuring a 301 redirect caused a loop, leading to the ERR_TOO_MANY_REDIRECTS error. The redirect rules have been updated to ensure proper routing from the Netlify subdomain to the custom domain without causing a loop.