### PR TITLE
Update robots.txt to disallow all crawlers

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
This PR includes and updates `robots.txt` to disallow all web crawlers from indexing the site. This is to ensure that uxit.fil.org does not appear in search engine results and compete with our main site fil.org. The `robots.txt` file now includes a directive to disallow all user agents from accessing any content on the site.