### PR TITLE
Revert "Update robots.txt to disallow all crawlers"

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,0 @@
-User-agent: *
-Disallow: /


### PR DESCRIPTION
Reverts FilecoinFoundationWeb/uxit#6

After further consideration and review, we have decided to revert the addition of robots.txt that was aimed at preventing the indexing of the subdomain uxit.fil.org.

Upon implementation, it was noted that the use of `robots.txt` is not the most effective approach for our use case. While the `robots.txt` file can instruct search engine bots not to crawl the specified paths, it does not entirely prevent the pages from being indexed. In some cases, the URLs can still appear in search results, especially if other pages link to them.

Instead, we will be using the `noindex` directive through meta tags, which is a more reliable method for ensuring that pages are not indexed by search engines. We will implement this directive using the `X-Robots-Tag` HTTP header.


> Don't use the `robots.txt` to block private content (use server-side authentication instead), or handle canonicalization. To make sure that a URL is not indexed, use the robots meta tag or X-Robots-Tag HTTP header instead.

https://developers.google.com/search/docs/crawling-indexing/robots/robots-faq#h02
