### PR TITLE
Add X-Robots-Tag header to prevent search engine indexing

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from "next/server";
+
+export function middleware() {
+  const response = NextResponse.next();
+  response.headers.set("X-Robots-Tag", "noindex, nofollow");
+  return response;
+}


### PR DESCRIPTION
Following the discussion in #7 , this PR introduces the use of the `X-Robots-Tag` HTTP header across all pages to ensure that search engines do not index or follow any links on our subdomain `uxit.fil.org`.

## Implementation
The `X-Robots-Tag` header has been added in the `middleware` function, ensuring it's applied to all server responses.

## Impact
- No page under the `uxit.fil.org` subdomain will be indexed by search engines.
- All existing `robots.txt` directives are superseded by this header.